### PR TITLE
Workaround for touch release not registering

### DIFF
--- a/Virtual Joystick/joystick/virtual_joystick.gd
+++ b/Virtual Joystick/joystick/virtual_joystick.gd
@@ -79,6 +79,10 @@ func _gui_input(event):
 		elif not event.pressed and _touch_index == event.index:
 			accept_event()
 			_reset()
+	elif event is InputEventMouseButton and not event.is_pressed():
+		accept_event()
+		_reset()
+
 	if event is InputEventScreenDrag and _touch_index == event.index:
 		accept_event()
 		_update_joystick(event.position)


### PR DESCRIPTION
Works around the problem that touch releases are not registered by resetting the joystick on mouse up. This works when emulating mouse from touch (in the project settings).