### PR TITLE
Correct issue with changing scale of joystick at runtime

### DIFF
--- a/joystick/virtual_joystick.gd
+++ b/joystick/virtual_joystick.gd
@@ -69,6 +69,7 @@ func _ready() -> void:
 		hide()
 
 func _input(event: InputEvent) -> void:
+	_base_radius = _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
 	if event is InputEventScreenTouch:
 		if event.pressed:
 			if _is_point_inside_joystick_area(event.position) and _touch_index == -1:

--- a/joystick/virtual_joystick.gd
+++ b/joystick/virtual_joystick.gd
@@ -55,8 +55,6 @@ var _touch_index : int = -1
 @onready var _base := $Base
 @onready var _tip := $Base/Tip
 
-@onready var _base_radius = _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
-
 @onready var _base_default_position : Vector2 = _base.position
 @onready var _tip_default_position : Vector2 = _tip.position
 
@@ -98,8 +96,11 @@ func _is_point_inside_joystick_area(point: Vector2) -> bool:
 	var y: bool = point.y >= global_position.y and point.y <= global_position.y + (size.y * get_global_transform_with_canvas().get_scale().y)
 	return x and y
 
+func _get_base_radius() -> float:
+	return _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
+
 func _is_point_inside_base(point: Vector2) -> bool:
-	_base_radius = _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
+	_base_radius = _get_base_radius()
 	var center : Vector2 = _base.global_position + _base_radius
 	var vector : Vector2 = point - center
 	if vector.length_squared() <= _base_radius.x * _base_radius.x:
@@ -108,7 +109,7 @@ func _is_point_inside_base(point: Vector2) -> bool:
 		return false
 
 func _update_joystick(touch_position: Vector2) -> void:
-	_base_radius = _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
+	_base_radius = _get_base_radius()
 	var center : Vector2 = _base.global_position + _base_radius
 	var vector : Vector2 = touch_position - center
 	vector = vector.limit_length(clampzone_size)

--- a/joystick/virtual_joystick.gd
+++ b/joystick/virtual_joystick.gd
@@ -69,7 +69,6 @@ func _ready() -> void:
 		hide()
 
 func _input(event: InputEvent) -> void:
-	_base_radius = _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
 	if event is InputEventScreenTouch:
 		if event.pressed:
 			if _is_point_inside_joystick_area(event.position) and _touch_index == -1:
@@ -100,6 +99,7 @@ func _is_point_inside_joystick_area(point: Vector2) -> bool:
 	return x and y
 
 func _is_point_inside_base(point: Vector2) -> bool:
+	_base_radius = _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
 	var center : Vector2 = _base.global_position + _base_radius
 	var vector : Vector2 = point - center
 	if vector.length_squared() <= _base_radius.x * _base_radius.x:
@@ -108,6 +108,7 @@ func _is_point_inside_base(point: Vector2) -> bool:
 		return false
 
 func _update_joystick(touch_position: Vector2) -> void:
+	_base_radius = _base.size * _base.get_global_transform_with_canvas().get_scale() / 2
 	var center : Vector2 = _base.global_position + _base_radius
 	var vector : Vector2 = touch_position - center
 	vector = vector.limit_length(clampzone_size)


### PR DESCRIPTION
If you have any method to handle window resizing which changes the scale of the joystick, the joystick ceases functioning once that runs. This fixes the issue and doesn't create any new ones as far as I can see. I don't think this has any performance hit, but if that is a concern I can modify the code to only rescale it based on a checkbox.