### PR TITLE
Update .gitattributes to ignore non-addons files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,14 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+
+# ------------------------------------------------------------------------------
+# Exclude everything except addons from zip downloads.
+# This makes installing through the AssetLib easier, because no files or
+# folders need to be unchecked.
+# ------------------------------------------------------------------------------
+# Exclude everything
+*                       export-ignore
+# Un-exclude addons
+/addons                -export-ignore
+/addons/**             -export-ignore


### PR DESCRIPTION
Just installed your plugin and had to uncheck README and another file when installing from asset library.  These additions (copied from my own plugin's .gitattributes) will ignore everything that is not in the addons folder in this project.