### PR TITLE
Fixed stuck input actions

### DIFF
--- a/addons/virtual_joystick/virtual_joystick.gd
+++ b/addons/virtual_joystick/virtual_joystick.gd
@@ -76,6 +76,8 @@ func _ready() -> void:
 	if visibility_mode == Visibility_mode.WHEN_TOUCHED:
 		hide()
 
+	_reset()
+
 func _input(event: InputEvent) -> void:
 	if event is InputEventScreenTouch:
 		if event.pressed:


### PR DESCRIPTION
This PR fixes stuck input actions if reload_current_scene() was called while action was pressed. 

before:
![example](https://github.com/user-attachments/assets/5ffacac8-987e-4dec-82e7-1f7266925fdf)
