### PR TITLE
Bug fix - joystick resets position when used inside layout containers

### DIFF
--- a/addons/virtual_joystick/virtual_joystick.gd
+++ b/addons/virtual_joystick/virtual_joystick.gd
@@ -76,6 +76,14 @@ func _ready() -> void:
 	if visibility_mode == Visibility_mode.WHEN_TOUCHED:
 		hide()
 
+	call_deferred("_post_layout_init")
+
+func _post_layout_init() -> void:
+	# These 2 variables do not have the correct values until after the containers have
+	# laid them out. So we wait for that to happen.
+	# Also _reset() can't be called before these variables have the correct values.
+	_base_default_position = _base.position
+	_tip_default_position = _tip.position
 	_reset()
 
 func _input(event: InputEvent) -> void:


### PR DESCRIPTION
Fixes #106 

I have a joystick inside a bunch of layout containers in my game's UI.
When it starts up everything is in the correct spot.
I press on the joystick and everything is good.
I release the joystick and it moves position even though I'm in mode "Fixed".

The problem is that _base_default_position and _tip_default_position are assigned values in @onready which is before the containers have put them in their correct positions.

The fix is to delay the value assignment until after the containers have finished moving them using call_deferred. The deferred function also calls _reset() ensuring it runs with the correct positions already captured and not before.